### PR TITLE
Respond with CF-cached beta server for all non-official data versions

### DIFF
--- a/src/servers.ts
+++ b/src/servers.ts
@@ -29,6 +29,13 @@ export const SERVER = {
       230227, 230329, 230503,
     ],
   },
+  beta: {
+    // Alias of the planet above that is proxied via CF and with enabled /maps/ *.mwm caching,
+    // to speed-up downloads for beta testers.
+    url: 'https://cdn-beta.organicmaps.app/',
+    // Can have any non-publicly available maps data version.
+    dataVersions: [],
+  },
   fi1: {
     // Hetzner Cloud (Helsinki, Finland), 20TB/mo
     url: 'https://cdn-fi1.organicmaps.app/',
@@ -90,7 +97,7 @@ export async function getServersList(request: Request) {
   }
   // Fallback to the planet with freshly generated/beta data.
   if (servers.length == 0) {
-    servers = [SERVER.planet];
+    servers = [SERVER.beta, SERVER.planet];
   }
   servers = servers.map((server) => server.url);
 

--- a/test/servers.test.ts
+++ b/test/servers.test.ts
@@ -33,7 +33,7 @@ describe('X-OM-DataVersion', () => {
     });
     const result = await getServersList(req);
     expect(result.status).toBe(200);
-    expect(JSON.parse(await result.text())).toEqual([SERVER.planet.url]);
+    expect(JSON.parse(await result.text())).toEqual([SERVER.beta.url, SERVER.planet.url]);
   });
 });
 


### PR DESCRIPTION
Бета юзеры получат ссылки на Cloudflare-proxied URL. Я выставил кеширование на неделю в Cloudflare Cache Rules. Можно выставить больше при желании, мы же эти mwm не меняем налету.

Здесь больше подробностей: https://github.com/organicmaps/infra/pull/23

@vng 