### PR TITLE
Don't use cdn-us1 (Cloudflare + Backbaze) for the actual versions

### DIFF
--- a/src/servers.ts
+++ b/src/servers.ts
@@ -129,8 +129,8 @@ export async function getServersList(request: Request) {
       case 'NA': // North America
       case 'SA': // South America
       case 'OC': // Oceania
-        servers = [SERVER.backblaze, SERVER.us_east1, SERVER.us_west1, SERVER.uk1, SERVER.nl1, SERVER.planet].filter(
-          (server) => DATA_VERSIONS.slice(-server.dataVersions).includes(dataVersion),
+        servers = [SERVER.us_east1, SERVER.us_west1, SERVER.uk1, SERVER.nl1, SERVER.planet].filter((server) =>
+          DATA_VERSIONS.slice(-server.dataVersions).includes(dataVersion),
         );
         break;
       default:


### PR DESCRIPTION
Cloudflare almost always have lowest ping, leaving no chance to other servers to server data for iOS users. Viktor reported some issues with Cloudflare from Argentina. "Let's see if us-west1 + us-east1 + uk1 + nl1 servers can handle America and Oceania.