### PR TITLE
Trap for cdn abusers with a specific map/app version

### DIFF
--- a/src/servers.ts
+++ b/src/servers.ts
@@ -123,7 +123,8 @@ export async function getServersList(request: Request) {
     // Older clients download from the archive.
     servers = [SERVER.backblaze];
   } else if (dataVersion == 240702 && request.headers.get('x-om-appversion') == '1.8.6-4-ios') {
-    // Redirect unknown bad guys who uses our servers to a slow download "trap" node.
+    // Redirect https://apps.apple.com/us/app/mapxplorer-navigation-radar/id6463052823
+    // who abuses our servers to a slow download "trap" node.
     return new Response('["https://cdn-fi2.organicmaps.app/"]', {
       headers: { 'Content-Type': 'application/json' },
     });


### PR DESCRIPTION
Upd: это вот эти ребята: https://apps.apple.com/us/app/mapxplorer-navigation-radar/id6463052823

Есть и аппа под андроид: https://play.google.com/store/apps/details?id=com.maps.radar.navigation.android2023

За сутки нагнали трафика почти на 1000 установок iOS.

Сервер настроен и работает, отдавая данные со скоростью 6кб/с, и логает все айпишники.

Цель: чтобы пользователи "левого" приложения на базе ОМ, которое использует наши серверы, начали жаловаться или лепить плохие оценки приложению. Если разработчики выпустят обновление с мастера, мы увидим айди и название их приложения в iCloud логах (если они конечно не догадаются и их не выпилят).

Этот код уже словил несколько клиентов за 20 минут:

```
alex@cdn-fi2:~$ sudo cat /var/log/nginx/badguys-access.log
105.40.99.11 [24/Oct/2024:06:55:17 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1568.100.1.2.1 Darwin/24.0.0"
84.72.175.236 [24/Oct/2024:06:56:45 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
178.115.43.201 [24/Oct/2024:06:57:50 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
84.72.175.236 [24/Oct/2024:06:58:03 +0000] "GET /maps/240702/Switzerland_Eastern.mwm HTTP/2.0" 200 522091 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
71.222.4.4 [24/Oct/2024:06:58:39 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1568.100.1.2.1 Darwin/24.0.0"
71.222.4.4 [24/Oct/2024:06:59:36 +0000] "GET /maps/240702/US_Nevada.mwm HTTP/2.0" 200 374799 "Organic%20Maps/4 CFNetwork/1568.100.1.2.1 Darwin/24.0.0"
71.222.4.4 [24/Oct/2024:06:59:47 +0000] "GET /maps/240702/US_Nevada.mwm HTTP/2.0" 200 60134 "Organic%20Maps/4 CFNetwork/1568.100.1.2.1 Darwin/24.0.0"
128.124.204.122 [24/Oct/2024:07:00:59 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
128.124.204.122 [24/Oct/2024:07:01:13 +0000] "GET /maps/240702/Ukraine_Kyiv%20Oblast.mwm HTTP/2.0" 200 93611 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
99.69.200.84 [24/Oct/2024:07:07:15 +0000] "GET /maps/240702/US_Missouri_Kansas.mwm HTTP/2.0" 206 4023556 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
178.115.43.201 [24/Oct/2024:07:08:05 +0000] "GET /maps/240702/Austria_Tyrol.mwm HTTP/2.0" 200 4083831 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
49.32.233.141 [24/Oct/2024:07:08:42 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
51.81.46.212 [24/Oct/2024:07:08:47 +0000] "GET / HTTP/1.1" 200 1548 "-"
49.32.233.141 [24/Oct/2024:07:09:12 +0000] "GET /maps/240702/India_Maharashtra.mwm HTTP/2.0" 200 194035 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
46.121.198.142 [24/Oct/2024:07:10:31 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
178.115.43.201 [24/Oct/2024:07:10:58 +0000] "GET /maps/240702/Austria_Tyrol.mwm HTTP/2.0" 206 1164793 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
185.12.130.72 [24/Oct/2024:07:11:54 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
46.121.198.142 [24/Oct/2024:07:12:03 +0000] "GET /maps/240702/Israel.mwm HTTP/2.0" 200 615819 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
185.12.130.72 [24/Oct/2024:07:13:23 +0000] "GET /maps/240702/Switzerland_Zurich.mwm HTTP/2.0" 200 595734 "Organic%20Maps/4 CFNetwork/1498.700.2 Darwin/23.6.0"
105.40.99.11 [24/Oct/2024:07:15:08 +0000] "GET /maps/240702/Egypt.mwm HTTP/2.0" 200 7980329 "Organic%20Maps/4 CFNetwork/1568.100.1.2.1 Darwin/24.0.0"
87.88.180.187 [24/Oct/2024:07:17:21 +0000] "HEAD / HTTP/2.0" 200 0 "Organic%20Maps/4 CFNetwork/1568.200.51 Darwin/24.1.0"
```
